### PR TITLE
apt-get install clang11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,8 @@ RUN wget https://github.com/massivethreads/massivethreads/archive/refs/tags/v1.0
     cd ../ && \
     rm -rf v1.00.tar.gz massivethreads-1.00
 
-RUN wget https://apt.llvm.org/llvm.sh && \
-    chmod +x llvm.sh && \
-    ./llvm.sh 11 && \
-    rm ./llvm.sh
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-11 main" >> /etc/apt/sources.list
 
 RUN wget -P /usr/share/keyrings https://github.com/smlsharp/repos/raw/main/debian/dists/buster/smlsharp-archive-keyring.gpg
 RUN wget -P /etc/apt/sources.list.d https://github.com/smlsharp/repos/raw/main/debian/dists/buster/smlsharp.list
@@ -33,6 +31,8 @@ RUN wget -P /etc/apt/sources.list.d https://github.com/smlsharp/repos/raw/main/d
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
       smlsharp \
+      clang-11 \
+      lld-11 \
       libgmp10 \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN wget https://github.com/massivethreads/massivethreads/archive/refs/tags/v1.0
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-11 main" >> /etc/apt/sources.list
 
-RUN wget -P /usr/share/keyrings https://github.com/smlsharp/repos/raw/main/debian/dists/buster/smlsharp-archive-keyring.gpg
-RUN wget -P /etc/apt/sources.list.d https://github.com/smlsharp/repos/raw/main/debian/dists/buster/smlsharp.list
+RUN wget -P /usr/share/keyrings https://github.com/smlsharp/repos/raw/main/debian/dists/buster/smlsharp-archive-keyring.gpg && \
+    wget -P /etc/apt/sources.list.d https://github.com/smlsharp/repos/raw/main/debian/dists/buster/smlsharp.list
 
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update -qq && \
       build-essential \
       ca-certificates \
       gnupg \
-      lsb-release \
-      software-properties-common \
       wget \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
llvm.sh installs lldb-11 and clangd-11, which is not needed in Docker image.
So I'd like to decrease the image size by installing llvm packages selectively by hand.